### PR TITLE
feat: add benchmark on flushing module

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/BenchmarkBase.java
+++ b/src/main/java/org/apache/flink/benchmark/BenchmarkBase.java
@@ -34,13 +34,13 @@ import static org.openjdk.jmh.annotations.Scope.Thread;
 @OutputTimeUnit(MILLISECONDS)
 @BenchmarkMode(Throughput)
 @Fork(
-        value = 3,
+        value = 1,
         jvmArgsAppend = {
             "-Djava.rmi.server.hostname=127.0.0.1",
             "-Dcom.sun.management.jmxremote.authenticate=false",
             "-Dcom.sun.management.jmxremote.ssl=false",
             "-Dcom.sun.management.jmxremote.ssl"
         })
-@Warmup(iterations = 10)
-@Measurement(iterations = 10)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 public class BenchmarkBase {}

--- a/src/main/java/org/apache/flink/benchmark/flush/AllowedLatencyBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/flush/AllowedLatencyBenchmark.java
@@ -1,0 +1,57 @@
+package org.apache.flink.benchmark.flush;
+
+import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.benchmark.BenchmarkBase;
+import org.apache.flink.benchmark.FlinkEnvironmentContext;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+public class AllowedLatencyBenchmark extends BenchmarkBase {
+    public static final int RECORDS_PER_INVOCATION = 5_000_000;
+    public static final long CHECKPOINT_INTERVAL_MS = 3000;
+    public static final long FLUSH_INTERVAL_MS = 0;
+    public static final int KEY_SIZE = 50_000;
+
+    public static void main(String[] args) throws RunnerException {
+        Options options =
+                new OptionsBuilder()
+                        .verbosity(VerboseMode.NORMAL)
+                        .include(".*" + AllowedLatencyBenchmark.class.getCanonicalName() + ".*")
+                        .build();
+
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(value = AllowedLatencyBenchmark.RECORDS_PER_INVOCATION)
+    public void aggregationSink(FlinkEnvironmentContext context) throws Exception {
+        StreamExecutionEnvironment env = context.env;
+        env.setStateBackend(new EmbeddedRocksDBStateBackend());
+        env.enableCheckpointing(CHECKPOINT_INTERVAL_MS);
+        env.getConfig().setAllowedLatency(FLUSH_INTERVAL_MS);
+        env.setParallelism(1);
+
+        DataStream<Integer> ds1 = env.addSource(new MyAggregationSource(
+                RECORDS_PER_INVOCATION,
+                0,
+                KEY_SIZE));
+        ds1.keyBy(value -> value)
+                .transform(
+                        "MyAggregator",
+                        new TupleTypeInfo<>(
+                                IntegerTypeInfo.INT_TYPE_INFO, IntegerTypeInfo.LONG_TYPE_INFO),
+                        new MyAggregator(value -> value))
+                .addSink(new CountingAndDiscardingSink<>());
+
+        env.execute();
+    }
+}

--- a/src/main/java/org/apache/flink/benchmark/flush/CountingAndDiscardingSink.java
+++ b/src/main/java/org/apache/flink/benchmark/flush/CountingAndDiscardingSink.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.benchmark.flush;
+
+import org.apache.flink.api.common.accumulators.LongCounter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+
+/**
+ * A stream sink that counts the number of all elements. The counting result is stored in an {@link
+ * org.apache.flink.api.common.accumulators.Accumulator} specified by {@link #COUNTER_NAME} and can
+ * be acquired by {@link
+ * org.apache.flink.api.common.JobExecutionResult#getAccumulatorResult(String)}.
+ *
+ * @param <T> The type of elements received by the sink.
+ */
+public class CountingAndDiscardingSink<T> extends RichSinkFunction<T> {
+    public static final String COUNTER_NAME = "numElements";
+
+    private static final long serialVersionUID = 1L;
+
+    private final LongCounter numElementsCounter = new LongCounter();
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        getRuntimeContext().addAccumulator(COUNTER_NAME, numElementsCounter);
+    }
+
+    @Override
+    public void invoke(T value, Context context) {
+        numElementsCounter.add(1L);
+    }
+}

--- a/src/main/java/org/apache/flink/benchmark/flush/MyAggregationSource.java
+++ b/src/main/java/org/apache/flink/benchmark/flush/MyAggregationSource.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.benchmark.flush;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/** A parallel source to generate data stream for aggregation operation. */
+public class MyAggregationSource extends RichParallelSourceFunction<Integer> {
+
+    private final int keySize;
+    private long numValues;
+    private long numValuesOnThisTask;
+    private Integer[] preGeneratedData;
+    private long pause;
+
+    public MyAggregationSource(long numValues, long pause, int keySize) {
+        this.numValues = numValues;
+        this.pause = pause;
+        this.keySize = keySize > 0 ? keySize : (int) Math.max(numValues / 1000, 100);
+    }
+
+    @Override
+    public final void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        int taskIdx = getRuntimeContext().getIndexOfThisSubtask();
+        int numTasks = getRuntimeContext().getNumberOfParallelSubtasks();
+        long div = numValues / numTasks;
+        long mod = numValues % numTasks;
+        numValuesOnThisTask = mod > taskIdx ? div + 1 : div;
+        preGeneratedData = new Integer[keySize];
+        for (int i = 0; i < keySize; i++) {
+            preGeneratedData[i] = i;
+        }
+    }
+
+    @Override
+    public void run(SourceContext ctx) throws Exception {
+        long cnt = 0;
+        while (cnt < this.numValuesOnThisTask) {
+            if (pause > 0 && cnt % pause == 0) {
+                TimeUnit.MILLISECONDS.sleep(getRandomSleepInterval());
+            }
+            ctx.collect(preGeneratedData[(int) (cnt % this.keySize)]);
+            cnt += 1;
+        }
+    }
+
+    private long getRandomSleepInterval() {
+        return ThreadLocalRandom.current().nextInt(300, 600);
+    }
+
+    @Override
+    public void cancel() {}
+}

--- a/src/main/java/org/apache/flink/benchmark/flush/MyAggregator.java
+++ b/src/main/java/org/apache/flink/benchmark/flush/MyAggregator.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.benchmark.flush;
+
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.PartitionableListState;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An aggregation operator with user-defined flush function.
+ *
+ * <p>The operator will buffer inputs in memory until a flush operation is triggered.
+ */
+public class MyAggregator extends AbstractStreamOperator<Tuple2<Integer, Long>>
+        implements OneInputStreamOperator<Integer, Tuple2<Integer, Long>> {
+    private Map<Integer, Long> bundle;
+    private final KeySelector<Integer, Integer> keySelector;
+    private int keySize = 0;
+    private int flushCnt = 0;
+    private ValueState<Long> store;
+    private long visits;
+    private PartitionableListState<Tuple2<Integer, Long>> bundleState;
+
+    public MyAggregator(KeySelector<Integer, Integer> keySelector) {
+        super();
+        this.keySelector = keySelector;
+    }
+
+    private Integer getKey(Integer input) throws Exception {
+        return keySelector.getKey(input);
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        bundleState.clear();
+        bundle.forEach((k, v) -> {
+            bundleState.add(new Tuple2<>(k, v));
+        });
+        LOG.info("Operator state size: {}", bundle.size());
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+        store =
+                context.getKeyedStateStore()
+                        .getState(new ValueStateDescriptor<>("store", Long.class));
+        bundle = new HashMap<>();
+        bundleState =
+                (PartitionableListState<Tuple2<Integer, Long>>) context.getOperatorStateStore()
+                        .getListState(new ListStateDescriptor<>("bundle", TypeInformation.of(new TypeHint<Tuple2<Integer, Long>>() {})));
+        if (context.isRestored()) {
+            for (Tuple2<Integer, Long> t : bundleState.get()) {
+                bundle.put(t.f0, t.f1);
+            }
+        }
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        visits = 0;
+    }
+
+    @Override
+    public void processElement(StreamRecord<Integer> element) throws Exception {
+        Integer input = element.getValue();
+        if (getExecutionConfig().getAllowedLatency() > 0
+                || getExecutionConfig().getFLushEnabled()) {
+            Long bundleValue = bundle.get(input);
+            // get a new value after adding this element to bundle
+            Long newBundleValue = bundleValue == null ? 1 : bundleValue + 1;
+            bundle.put(input, newBundleValue);
+        } else {
+            visits += 1;
+            Long storeValue = store.value();
+            Long newStoreValue = storeValue == null ? 1 : storeValue + 1;
+            store.update(newStoreValue);
+            output.collect(new StreamRecord<>(new Tuple2<>(input, newStoreValue)));
+        }
+    }
+
+    @Override
+    public void finish() throws Exception {
+        finishBundle();
+        System.out.println("RocksDB visits: " + visits);
+        if (flushCnt > 0) {
+            System.out.println("Average key size: " + keySize / flushCnt);
+        }
+    }
+
+    public void finishBundle() throws Exception {
+        if (bundle != null && !bundle.isEmpty()) {
+            keySize += bundle.size();
+            flushCnt++;
+            finishBundle(bundle, output);
+            bundle.clear();
+        }
+    }
+
+    public void finishBundle(
+            Map<Integer, Long> bundle,
+            Output<StreamRecord<Tuple2<Integer, Long>>> output)
+            throws Exception {
+        bundle.forEach((k, v) -> {
+            try {
+                visits += 1;
+                setKeyContextElement1(new StreamRecord<>(k));
+                Long storeValue = store.value();
+                Long newStoreValue = storeValue == null ? v : storeValue + v;
+                store.update(newStoreValue);
+                output.collect(new StreamRecord<>(new Tuple2<>(k, newStoreValue)));
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+    }
+
+    @Override
+    public void flush() throws Exception {
+        finishBundle();
+    }
+}


### PR DESCRIPTION
## RocksDB State Backend
| Checkpoint Interval | Flush Interval | Key Count | Throughput | Data | RocksDB Visits |
| ---- | ---- | ---- | ---- | ---- | ---- |
| 3000ms | 1000ms | 5e5 | 8360.244 ± 679.790  ops/ms | 5e7 | 350000 |
| 3000ms | disabled | 5e5 | 208.483 ± 25.629  ops/ms | 5e7 | 5e7 |

## HashMap State Backend
| Checkpoint Interval | Flush Interval | Key Count | Throughput | Data | Memory Visits |
| ---- | ---- | ---- | ---- | ---- | ---- |
| 3000ms | 1000ms | 5e5 | 10465.543 ± 1947.282  ops/ms | 5e7 | 350000 |
| 3000ms | disabled | 5e5 | 4161.551 ± 572.344  ops/ms | 5e7 | 5e7 |

## Different Number of Keys
| Checkpoint Interval | Flush Interval | Key Count | Throughput | Data | RocksDB Visits |
| ---- | ---- | ---- | ---- | ---- | ---- |
| disabled | 2000ms | 5e3 | 8543  ops/ms | 1e8 | 30000 |
| disabled | 2000ms | 5e5 | 2614  ops/ms | 1e8 | 7166242 |

## Checkpoint Snapshot Duration(synchronous part)
| Checkpoint Interval | Flush Interval | Key Count |Duration | 
| ---- | ---- | ---- | ---- |
| 3000ms | disabled | 3e4 | 25  ms |
| 3000ms | 300ms | 3e4 | 35 ms |
| 3000ms | 2000ms | 3e4 | 18  ms |
| 3000ms | 10000ms | 3e4 | 4  ms / 16 ms |
| 3000ms | 30000ms | 3e4 | 4 ms / 16 ms |

The flush operation's impact on synchronous part of snapshot duration mainly depends on both flush interval and checkpoint interval. 
If at least one flush operation is triggered between two checkpoints, then both operator state (in heap memory) and keyed states (in RocksDB backend) would be serialized.
If no flush operation in between, only operator state would be serialized, generally taking much shorter time.